### PR TITLE
Added more options for the BlueMap lines in the config

### DIFF
--- a/src/main/java/dev/szedann/create_bluemap/Config.java
+++ b/src/main/java/dev/szedann/create_bluemap/Config.java
@@ -32,6 +32,32 @@ public class Config
             .comment("Whether to render trains")
             .define("renderTrains", true);
 
+    private static final ModConfigSpec.IntValue LINE_WIDTH_TRAINS = BUILDER
+            .comment("")
+            .comment("Graphical options for displayed lines in BlueMap")
+            .comment("")
+            .comment("line width:")
+            .comment("Width of the train lines")
+            .defineInRange("lineWidthTrains", 6, 1, 20);
+
+    private static final ModConfigSpec.IntValue LINE_WIDTH_TRACKS = BUILDER
+            .comment("Width of the train track lines")
+            .defineInRange("lineWidthTracks", 6, 1, 20);
+
+    private static final ModConfigSpec.ConfigValue<String> LINE_COLOR_TRACKS = BUILDER
+            .comment("")
+            .comment("line colors:")
+            .comment("Color of the train track lines; HEX value")
+            .define("lineColorTracks", "#fff");
+
+    private static final ModConfigSpec.ConfigValue<String> LINE_COLOR_MANUAL_TRAINS = BUILDER
+            .comment("Color of trains without schedules; HEX value")
+            .define("lineColorManualTrains", "#f99");
+
+    private static final ModConfigSpec.ConfigValue<String> LINE_COLOR_SCHEDULED_TRAINS = BUILDER
+            .comment("Color of trains with schedules; HEX value")
+            .define("lineColorScheduledTrains", "#99f");
+
     static final ModConfigSpec SPEC = BUILDER.build();
 
     public static int trainInterval;
@@ -39,6 +65,11 @@ public class Config
     public static boolean renderTracks;
     public static boolean renderCarriages;
     public static boolean renderTrains ;
+    public static int lineWidthTrains;
+    public static int lineWidthTracks;
+    public static String lineColorTracks;
+    public static String lineColorManualTrains;
+    public static String lineColorScheduledTrains;
 
     private static void applyValues(){
         trainInterval = INTERVAL_TRAINS.get();
@@ -46,6 +77,11 @@ public class Config
         renderTracks = RENDER_TRACKS.get();
         renderCarriages = RENDER_CARRIAGES.get();
         renderTrains  = RENDER_TRAINS.get();
+        lineWidthTrains = LINE_WIDTH_TRAINS.get();
+        lineWidthTracks = LINE_WIDTH_TRACKS.get();
+        lineColorTracks = LINE_COLOR_TRACKS.get();
+        lineColorManualTrains = LINE_COLOR_MANUAL_TRAINS.get();
+        lineColorScheduledTrains = LINE_COLOR_SCHEDULED_TRAINS.get();
     }
 
     @SubscribeEvent

--- a/src/main/java/dev/szedann/create_bluemap/Tracks.java
+++ b/src/main/java/dev/szedann/create_bluemap/Tracks.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class Tracks {
-    private static final Color trackColor = new Color(Config.lineColorTracks);
     public static void update(BlueMapAPI api) {
         if (!Config.renderTracks) return;
         Map<ResourceKey<Level>, MarkerSet> lineMarkerSets = new HashMap<>();
@@ -49,7 +48,7 @@ public class Tracks {
                         .label("edge")
                         .depthTestEnabled(false)
                         .listed(false)
-                        .lineColor(trackColor)
+                        .lineColor(new Color(Config.lineColorTracks))
                         .build();
 
                 lineMarkerSet.put(edge.toString(), marker);

--- a/src/main/java/dev/szedann/create_bluemap/Tracks.java
+++ b/src/main/java/dev/szedann/create_bluemap/Tracks.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class Tracks {
-    private static final Color trackColor = new Color("#fff");
+    private static final Color trackColor = new Color(Config.lineColorTracks);
     public static void update(BlueMapAPI api) {
         if (!Config.renderTracks) return;
         Map<ResourceKey<Level>, MarkerSet> lineMarkerSets = new HashMap<>();
@@ -44,7 +44,7 @@ public class Tracks {
                 addEdge(line, edge, graph, false);
                 LineMarker marker = LineMarker.builder()
                         .line(line.build())
-                        .lineWidth(6)
+                        .lineWidth(Config.lineWidthTracks)
 //                        .maxDistance(300)
                         .label("edge")
                         .depthTestEnabled(false)

--- a/src/main/java/dev/szedann/create_bluemap/Tracks.java
+++ b/src/main/java/dev/szedann/create_bluemap/Tracks.java
@@ -19,6 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class Tracks {
+    private static final Color trackColor = new Color(Config.lineColorTracks);
+
     public static void update(BlueMapAPI api) {
         if (!Config.renderTracks) return;
         Map<ResourceKey<Level>, MarkerSet> lineMarkerSets = new HashMap<>();
@@ -48,7 +50,7 @@ public class Tracks {
                         .label("edge")
                         .depthTestEnabled(false)
                         .listed(false)
-                        .lineColor(new Color(Config.lineColorTracks))
+                        .lineColor(trackColor)
                         .build();
 
                 lineMarkerSet.put(edge.toString(), marker);

--- a/src/main/java/dev/szedann/create_bluemap/Trains.java
+++ b/src/main/java/dev/szedann/create_bluemap/Trains.java
@@ -20,6 +20,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Trains {
+    private static final Color manualColor = new Color(Config.lineColorScheduledTrains);
+    private static final Color scheduledColor = new Color(Config.lineColorManualTrains);
+
     public static void update(BlueMapAPI api) {
         if (Config.renderTrains)
             updatePOIs(api);
@@ -91,10 +94,7 @@ public class Trains {
                                 .addPoint(new Vector3d(p1.x, p1.y + 1, p1.z))
                                 .addPoint(new Vector3d(p2.x, p2.y + 1, p2.z))
                                 .build())
-                        .lineColor(
-                            scheduled ? 
-                            new Color(Config.lineColorScheduledTrains) : 
-                            new Color(Config.lineColorManualTrains))
+                        .lineColor(scheduled ? manualColor : scheduledColor)
                         .lineWidth(front ? Config.lineWidthTrains +2 : Config.lineWidthTrains)
                         .depthTestEnabled(false)
                         // .maxDistance(400)

--- a/src/main/java/dev/szedann/create_bluemap/Trains.java
+++ b/src/main/java/dev/szedann/create_bluemap/Trains.java
@@ -20,9 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Trains {
-    private static final Color manualColor = new Color("#f99");
-    private static final Color scheduledColor = new Color("#99f");
-
     public static void update(BlueMapAPI api) {
         if (Config.renderTrains)
             updatePOIs(api);
@@ -94,8 +91,11 @@ public class Trains {
                                 .addPoint(new Vector3d(p1.x, p1.y + 1, p1.z))
                                 .addPoint(new Vector3d(p2.x, p2.y + 1, p2.z))
                                 .build())
-                        .lineColor(scheduled ? scheduledColor : manualColor)
-                        .lineWidth(front ? 7 : 5)
+                        .lineColor(
+                            scheduled ? 
+                            new Color(Config.lineColorScheduledTrains) : 
+                            new Color(Config.lineColorManualTrains))
+                        .lineWidth(front ? Config.lineWidthTrains +2 : Config.lineWidthTrains)
                         .depthTestEnabled(false)
                         // .maxDistance(400)
                         .build());


### PR DESCRIPTION
# Added more options for the BlueMap lines in the config

This options let the server-owner change the width and color of tracks and trains. 
The first carrige of a train is always: `lineWidthTrains + 2`
The color of manual trains and scheduled trains can be configured separat.

```
#Graphical options for displayed lines in BlueMap
#
#line width:
#Width of the train lines
# Default: 6
# Range: 1 ~ 20
lineWidthTrains = 6
#Width of the train track lines
# Default: 6
# Range: 1 ~ 20
lineWidthTracks = 6
#
#line colors:
#Color of the train track lines; HEX value
lineColorTracks = "#fff"
#Color of trains without schedules; HEX value
lineColorManualTrains = "#f99"
#Color of trains with schedules; HEX value
lineColorScheduledTrains = "#99f"
```
